### PR TITLE
Get closer to “it just works” installation

### DIFF
--- a/CoreServices/archive/diachron-archive/archive-system/pom.xml
+++ b/CoreServices/archive/diachron-archive/archive-system/pom.xml
@@ -20,6 +20,16 @@
 			<name>University Leipzig, AKSW Maven2 Repository</name>
 			<url>http://maven.aksw.org/archiva/repository/internal</url>
 		</repository>
+		<repository>
+			<id>virtjdbc4.snapshots/</id>
+			<name>University Leipzig, AKSW Maven2 virtjdbc4 Repository</name>
+			<url>http://maven.aksw.org/repository/internal/com/openlink/virtuoso/virtjdbc4/</url>
+		</repository>
+		<repository>
+			<id>virt_jena2.snapshots/</id>
+			<name>University Leipzig, AKSW Maven2 virt_jena2 Repository</name>
+			<url>http://maven.aksw.org/repository/internal/com/openlink/virtuoso/virt_jena2/</url>
+		</repository>
 	</repositories>
 
 	<dependencies>
@@ -42,8 +52,8 @@
 		</dependency>
 		<dependency>
 			<groupId>com.openlink.virtuoso</groupId>
-			<artifactId>virtjena2</artifactId>
-			<version>1.0.0</version>
+			<artifactId>virt_jena2</artifactId>
+			<version>7.1.0</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.commons</groupId>

--- a/CoreServices/archive/diachron-archive/archive-web-services/pom.xml
+++ b/CoreServices/archive/diachron-archive/archive-web-services/pom.xml
@@ -56,8 +56,8 @@
 		</dependency>
 		<dependency>
 			<groupId>com.openlink.virtuoso</groupId>
-			<artifactId>virtjena2</artifactId>
-			<version>1.0.0</version>
+			<artifactId>virt_jena2</artifactId>
+			<version>7.1.0</version>
 		</dependency>
 		<dependency>
 			<groupId>javax.servlet</groupId>

--- a/CoreServices/archive/diachron-archive/pom.xml
+++ b/CoreServices/archive/diachron-archive/pom.xml
@@ -10,4 +10,22 @@
   	<module>archive-web-services</module>
   	<module>archive-data-mapping</module>
   </modules>
+
+  <repositories>
+    <repository>
+      <id>maven.aksw.snapshots/</id>
+      <name>University Leipzig, AKSW Maven2 Repository</name>
+      <url>http://maven.aksw.org/archiva/repository/internal</url>
+    </repository>
+    <repository>
+      <id>virtjdbc4.snapshots/</id>
+      <name>University Leipzig, AKSW Maven2 virtjdbc4 Repository</name>
+      <url>http://maven.aksw.org/repository/internal/com/openlink/virtuoso/virtjdbc4/</url>
+    </repository>
+    <repository>
+      <id>virt_jena2.snapshots/</id>
+      <name>University Leipzig, AKSW Maven2 virt_jena2 Repository</name>
+      <url>http://maven.aksw.org/repository/internal/com/openlink/virtuoso/virt_jena2/</url>
+    </repository>
+  </repositories>
 </project>

--- a/CoreServices/archive/diachron-archive/pom.xml
+++ b/CoreServices/archive/diachron-archive/pom.xml
@@ -28,4 +28,17 @@
       <url>http://maven.aksw.org/repository/internal/com/openlink/virtuoso/virt_jena2/</url>
     </repository>
   </repositories>
+  <build>
+    <plugins>
+    <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>2.3</version>
+        <configuration>
+          <source>1.6</source>
+          <target>1.6</target>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>


### PR DESCRIPTION
- Fix dependency names/defaults
- Add Maven repository configs for dependencies
- Set explicit Java build target, to prevent compile failure on platforms where the default build target is an older JVM
